### PR TITLE
Add delete_mailbox feature to Mail object

### DIFF
--- a/sute/objects.py
+++ b/sute/objects.py
@@ -47,6 +47,20 @@ class Mail:
             mail_data.append(Message(self.client, **content))
         return mail_data
 
+    def delete_mailbox(self) -> int:
+        res = self.client.get_request(
+            Config.HOST + Config.PATH_ADDRESS_LIST
+        )
+        soup = BeautifulSoup(res.text, "html.parser")
+        mail_num = soup.find("span",string=self.address).get("id").split("addr_")[1]
+        params = self._create_payload()
+        params.update([ ("action","delAddrList") , ("num_list",mail_num) ])
+
+        res = self.client.get_request(
+            Config.HOST + Config.PATH_ADDRESS_LIST, params=params
+        )
+        return res.status_code
+
     def _create_payload(self) -> dict:
         return {
             "nopost": 1,

--- a/sute/objects.py
+++ b/sute/objects.py
@@ -48,13 +48,11 @@ class Mail:
         return mail_data
 
     def delete_mailbox(self) -> int:
-        res = self.client.get_request(
-            Config.HOST + Config.PATH_ADDRESS_LIST
-        )
+        res = self.client.get_request(Config.HOST + Config.PATH_ADDRESS_LIST)
         soup = BeautifulSoup(res.text, "html.parser")
-        mail_num = soup.find("span",string=self.address).get("id").split("addr_")[1]
+        mail_num = soup.find("span", string=self.address).get("id").split("addr_")[1]
         params = self._create_payload()
-        params.update([ ("action","delAddrList") , ("num_list",mail_num) ])
+        params.update([("action", "delAddrList"), ("num_list", mail_num)])
 
         res = self.client.get_request(
             Config.HOST + Config.PATH_ADDRESS_LIST, params=params


### PR DESCRIPTION
Works on kuku.lu, i guess it also works for sute in general. Feature preview on python shell:
```
>>> box.mails
[<sute.objects.Mail object at 0x7f60a591f390>, <sute.objects.Mail object at 0x7f60a591f320>]
>>> box.mails[1].delete_mailbox()
200
>>> box.refresh_address_list()
>>> box.mails
[<sute.objects.Mail object at 0x7f60a592ddd8>]
```