### PR TITLE
bypass csrf_subtoken_check & captcha

### DIFF
--- a/sute/config.py
+++ b/sute/config.py
@@ -6,7 +6,11 @@ class Config:
     PATH_MAIL_LIST = "/recv._ajax.php"
     PATH_MAIL_CONTENT = "/smphone.app.recv.view.php"
 
-    HEADERS: dict = {}
+    HEADERS: dict = {
+        "User-agent": "Mozilla/5.0 (Linux; Android 8.0.0;"
+        "MI 5s Build/OPR1.170623.032) AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/79.0.3945.4 Mobile Safari/537.36 YaApp_Android/10.30 YaSearchBrowser/10.30"
+    }
 
     SESSION_ID_KEY = "cookie_uidenc_seted"
     CSRF_TOKEN_KEY = "cookie_csrf_token"

--- a/sute/objects.py
+++ b/sute/objects.py
@@ -63,6 +63,8 @@ class Mail:
             "nopost": 1,
             "q": self.address,
             "_": Func.get_epoctime_int(),
+            "csrf_token_check": self.client.get_csrf_token(),
+            "csrf_subtoken_check": self.client.get_csrf_subtoken(),
         }
 
 

--- a/sute/sute.py
+++ b/sute/sute.py
@@ -71,6 +71,7 @@ class Sute:
             "nopost": 1,
             "UID_enc": self.client.get_session_id(),
             "csrf_token_check": self.client.get_csrf_token(),
+            "csrf_subtoken_check": self.client.get_csrf_subtoken(),
             "newuser": user,
             "newdomain": domain,
             "_": Func.get_epoctime_int(),


### PR DESCRIPTION
m.kuku.lu has added a new csrf key called "csrf_substring_check" which broke the script.
get_mail_list() doesn't return anything since it was getting this error:
>NG:CSRF Security Error!

Also kuku.lu started to represent a captcha after 4 requests. But using an android user-agent header lets you send unlimited requests.